### PR TITLE
Add Termux section on troubleshooting

### DIFF
--- a/docs/_docs/troubleshooting.md
+++ b/docs/_docs/troubleshooting.md
@@ -65,6 +65,12 @@ sudo emerge -av dev-ruby/rubygems
 On Windows, you may need to install [RubyInstaller
 DevKit](https://wiki.github.com/oneclick/rubyinstaller/development-kit).
 
+On Android (with Termux) you can install all requirements by running: 
+
+```sh
+apt update && apt install libffi-dev clang ruby-dev make
+```
+
 On macOS, you may need to update RubyGems (using `sudo` only if necessary):
 
 ```sh


### PR DESCRIPTION
Someone recently ran into problems installing the requirements on Android (see https://github.com/termux/termux-packages/issues/713).

This PR documents the solution found in that issue.